### PR TITLE
Fix readme link, retry release pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2022-07-01
+
+- fix readme link, retry release pipeline
+
 ## [0.2.0] - 2022-07-01
 
 - add buffs to remind/warn of remaining lives

--- a/ModInfo.xml
+++ b/ModInfo.xml
@@ -3,7 +3,7 @@
         <Name value="Amnesia" />
         <Description value="Reset player progress after a configurable number of deaths" />
         <Author value="Jonathan Robertson (Kanaverum)" />
-        <Version value="0.2.0" />
+        <Version value="0.2.1" />
         <Website value="https://github.com/jonathan-robertson/amnesia" />
     </ModInfo>
 </xml>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Amnesia [![Tested with A20.5 b2](https://img.shields.io/badge/A20.5%20b2-tested-blue.svg)](https://7daystodie.com/) [![Automated Release](https://github.com/jonathan-robertson/only-three-chances/actions/workflows/main.yml/badge.svg)](https://github.com/jonathan-robertson/only-three-chances/actions/workflows/main.yml)
+# Amnesia [![Tested with A20.5 b2](https://img.shields.io/badge/A20.5%20b2-tested-blue.svg)](https://7daystodie.com/) [![Automated Release](https://github.com/jonathan-robertson/amnesia/actions/workflows/main.yml/badge.svg)](https://github.com/jonathan-robertson/amnesia/actions/workflows/main.yml)
 
 *Reset player progress after a configurable number of deaths.*
 


### PR DESCRIPTION
- fix readme link, retry release pipeline
- add buffs to remind/warn of remaining lives
- add xp boost to encourage recently reset players