### PR TITLE
Fix Bug Allowing Bypass of PVP Protection, Add/Update Console Commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## TODO
+
+- update localization for amnesia buffs (instruct player to seek treatment from traders, maybe even show treatment cost)
+- update tooltips to no longer use orange color (interferes with player arm color)
+
 ## [UNRELEASED]
 
+- add dialog purchasing system for treatments
 - remove deprecated buff
 
 ## [1.2.0] - 2023-05-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## TODO
 
+- test level up on local to ensure it triggers therapy cost adjustment
+- test login on local to ensure it triggers therapy cost adjustment
 - update localization for amnesia buffs (instruct player to seek treatment from traders, maybe even show treatment cost)
-- update tooltips to no longer use orange color (interferes with player arm color)
+- update amn help command to return info around `buffAmnesiaFragileMemory` instead of hardened memory
 
 ## [UNRELEASED]
 
 - add dialog purchasing system for treatments
 - remove deprecated buff
+- update therapy prices on login and level-up
 
 ## [1.2.0] - 2023-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+- remove deprecated buff
+
 ## [1.2.0] - 2023-05-31
 
 - add clarification for blood moon protection buff

--- a/Config/Localization.txt
+++ b/Config/Localization.txt
@@ -32,12 +32,10 @@ drugAmnesiaMemoryBoostersDesc,items,Medical,"Ingesting this special drug/vitamin
 statStopsFragileMemory,ui_display,Item stat,"Cure Fragile Memory"
 
 
-dialog_trader_response_background,Quest,Dialogs,"Can you give me some information? ([007fff]{cvar($LastPlayerLevel)}[-])"
-
 dialog_trader_response_memory,Quest,Dialogs,"Can you help with my memory?"
-dialog_trader_statement_memory,Quest,Dialogs,"Sure, what can I do for you? [ff8000]Listed prices are based on your level[-]."
-dialog_trader_response_treatment,Quest,Dialogs,"Please treat my fragile memory. [[007fff]$5000[-]] [[007fff]${cvar($LastPlayerLevel)}[-]]"
-dialog_trader_response_therapy,Quest,Dialogs,"Please help me to rethink my skills. [[007fff]$5000[-]]"
+dialog_trader_statement_memory,Quest,Dialogs,"Sure, what can I do for you? (Listed prices are based on your level)"
+dialog_trader_response_treatment,Quest,Dialogs,"Please treat my fragile memory. [[007fff]${cvar(amnesiaTreatmentPrice)}[-]]"
+dialog_trader_response_therapy,Quest,Dialogs,"Please help me to rethink my skills. [[007fff]${cvar(amnesiaTherapyPrice)}[-]]"
 
 tipCannotAfford,buffs,Buffs,"[ff8000]You do not have the necessary funds[-] for this procedure. Please return when you do."
 tipTreatmentNotNecessary,buffs,Buffs,"You have no need of Treatment since [00ff80]your memory is already healthy[-]. Please visit again if you acquire a [ff8000]Fragile Memory[-]."

--- a/Config/Localization.txt
+++ b/Config/Localization.txt
@@ -30,3 +30,19 @@ drugAmnesiaMemoryBoosters,items,Medical,"Trader Jen's Memory Boosters"
 drugAmnesiaMemoryBoostersDesc,items,Medical,"Ingesting this special drug/vitamin cocktail loaded with omega-3 fatty acids will stabilize a [ff8000]Fragile Memory[-].\n\n[007fff]Don't Forget, Get BOOSTED![-]\n - Trader Jen's Experimental Pharmaceuticals"
 
 statStopsFragileMemory,ui_display,Item stat,"Cure Fragile Memory"
+
+
+dialog_trader_response_background,Quest,Dialogs,"Can you give me some information? ([007fff]{cvar($LastPlayerLevel)}[-])"
+
+dialog_trader_response_memory,Quest,Dialogs,"Can you help with my memory?"
+dialog_trader_statement_memory,Quest,Dialogs,"Sure, what can I do for you? [ff8000]Listed prices are based on your level[-]."
+dialog_trader_response_treatment,Quest,Dialogs,"Please treat my fragile memory. [[007fff]$5000[-]] [[007fff]${cvar($LastPlayerLevel)}[-]]"
+dialog_trader_response_therapy,Quest,Dialogs,"Please help me to rethink my skills. [[007fff]$5000[-]]"
+
+tipCannotAfford,buffs,Buffs,"[ff8000]You do not have the necessary funds[-] for this procedure. Please return when you do."
+tipTreatmentNotNecessary,buffs,Buffs,"You have no need of Treatment since [00ff80]your memory is already healthy[-]. Please visit again if you acquire a [ff8000]Fragile Memory[-]."
+tipTreatmentComplete,buffs,Buffs,"[00ff80]Your treatment is now complete[-] and your memory has returned to a health state. Please come again!"
+tipTherapyComplete,buffs,Buffs,"[00ff80]Your therapy is now complete[-] and your skillpoints can be reassigned. Please come again!"
+
+dialog_trader_statement_treatment,Quest,Dialogs,"All better!"
+dialog_trader_statement_therapy,Quest,Dialogs,"You got it!"

--- a/Config/buffs.xml
+++ b/Config/buffs.xml
@@ -10,15 +10,6 @@
     <set xpath="/buffs/buff[@name='buffNewbieCoat']/effect_group/triggered_effect/requirement[@name='PlayerLevel']/@value">@amnesiaLongTermMemoryLevel</set>
 
     <append xpath="/buffs">
-        <!-- TODO: remove for 2.0.0 - deprecated: keeping around until then for backwards compatibility -->
-        <buff name="buffAmnesiaHardenedMemory" remove_on_death="false" hidden="true">
-            <duration value="0" />
-            <stack_type value="ignore" />
-            <effect_group>
-                <triggered_effect trigger="onSelfBuffRemove" action="ShowToolbeltMessage" message_key="buffAmnesiaHardenedMemoryRemoveTooltip" />
-            </effect_group>
-        </buff>
-
         <buff name="buffAmnesiaFragileMemory" name_key="buffAmnesiaFragileMemoryName" description_key="buffAmnesiaFragileMemoryDesc" icon="ui_game_symbol_intellect" icon_color="255,128,0" remove_on_death="false">
             <duration value="0" />
             <stack_type value="ignore" />

--- a/Config/buffs.xml
+++ b/Config/buffs.xml
@@ -5,7 +5,6 @@
         </effect_group>
     </append>
 
-
     <set xpath="/buffs/buff[@name='buffNewbieCoat']/effect_group/requirement[@name='PlayerLevel']/@value">@amnesiaLongTermMemoryLevel</set>
     <set xpath="/buffs/buff[@name='buffNewbieCoat']/effect_group/triggered_effect/requirement[@name='PlayerLevel']/@value">@amnesiaLongTermMemoryLevel</set>
 
@@ -97,6 +96,17 @@
                 <triggered_effect trigger="onSelfBuffRemove" action="ModifyCVar" cvar="$postBloodmoonProtectionTime" operation="set" value="0" />
                 <triggered_effect trigger="onSelfBuffRemove" action="ShowToolbeltMessage" message_key="buffAmnesiaBloodmoonLifeProtectionEndTooltip" />
             </effect_group>
+        </buff>
+
+        <buff name="buffAmnesiaTryBuyTreatment" hidden="true" remove_on_death="false">
+            <stack_type value="ignore" />
+            <duration value="0" />
+            <!-- wait for server to process and remove this, along with buffAmnesiaFragileMemory -->
+        </buff>
+        <buff name="buffAmnesiaRequestChangeCallback" hidden="true" remove_on_death="false">
+            <stack_type value="ignore" />
+            <duration value="0" />
+            <!-- wait for server to process and remove this, along with buffAmnesiaFragileMemory -->
         </buff>
     </append>
     <!-- TODO: explore how onCombatEntered works: perhaps a screen effect could be added when on last life onCombatEntered as a reminder -->

--- a/Config/dialogs.xml
+++ b/Config/dialogs.xml
@@ -1,0 +1,55 @@
+<config>
+    <insertBefore xpath="/dialogs/dialog[@id='trader' or @id='traderTest']/statement[@id='start']/response_entry[@id='admin']">
+        <response_entry id="memory" />
+        <!-- <response_entry id="background" /> -->
+    </insertBefore>
+    <!-- <append xpath="/dialogs/dialog/response[@id='background']"> -->
+
+    <!-- try -->
+    <!-- <requirement type="QuestsAvailable" value="special" requirementtype="Hide" /> -->
+    <!-- <requirement type="QuestStatus" value="InProgress" requirementtype="Hide" tag="amnesia" /> -->
+    <!-- <requirement type="QuestStatus" value="TurnInReady" requirementtype="Hide" tag="amnesia" /> -->
+    <!-- <requirement type="QuestStatus" value="CanReceive" requirementtype="Hide" tag="amnesia" /> -->
+    <!-- <requirement type="QuestStatus" value="CannotReceive" requirementtype="Hide" tag="amnesia" /> -->
+    <!-- <requirement type="Buff" tag="buffAmnesiaFragileMemory" requirementtype="Hide" /> -->
+
+
+    <!-- does not work -->
+
+    <!-- works... kinda? -->
+    <!-- <requirement type="QuestStatus" value="NotStarted" requirementtype="Hide" tag="amnesia" /> -->
+    <!-- <requirement type="QuestsAvailable" value="amnesia" requirementtype="Hide" /> -->
+
+    <!-- type => id, value, tag, requirementtype -->
+    <!-- </append> -->
+    <append xpath="/dialogs/dialog[@id='trader' or @id='traderTest']">
+        <response id="memory" text="dialog_trader_response_memory" nextstatementid="memory" />
+        <!-- TODO: remove - this flow was no good -->
+        <!-- <statement id="memory" text="dialog_trader_statement_memory">
+            <quest_entry id="amnesia_Treatment" type="add" listindex="0" />
+            <quest_entry id="amnesia_Therapy" type="add" listindex="1" />
+            <response_entry id="nevermind" />
+        </statement> -->
+
+        <statement id="memory" text="dialog_trader_statement_memory">
+            <response_entry id="treatment" />
+            <response_entry id="therapy" />
+
+            <response_entry id="nevermind" />
+        </statement>
+        <!--  nextstatementid="treatment" -->
+        <response id="treatment" text="dialog_trader_response_treatment">
+            <!-- TODO: buff here that auto-transforms into another buff (for capture by server), based on held money -->
+            <!-- TODO: use tooltips to give response -->
+            <action type="AddBuff" id="buffAmnesiaTryBuyTreatment" />
+        </response>
+        <!--  nextstatementid="therapy" -->
+        <response id="therapy" text="dialog_trader_response_therapy">
+            <!-- TODO: buff here that auto-transforms into another buff (for capture by server), based on held money -->
+            <!-- TODO: use tooltips to give response -->
+            <action type="AddBuff" id="buffAmnesiaTryBuyTreatment" />
+        </response>
+        <!-- <statement id="treatment" text="dialog_trader_statement_treatment" nextstatementid="start" />
+        <statement id="therapy" text="dialog_trader_statement_therapy" nextstatementid="start" /> -->
+    </append>
+</config>

--- a/Config/gameevents.xml
+++ b/Config/gameevents.xml
@@ -1,0 +1,29 @@
+<config>
+    <append xpath="/gameevents">
+        <action_sequence name="amnesia_pay_from_bag">
+            <action class="RemoveItems">
+                <property name="items_location" value="Backpack" />
+                <property name="remove_item_tag" value="amnesiaCurrency" />
+            </action>
+        </action_sequence>
+        <action_sequence name="amnesia_pay_from_blt">
+            <action class="RemoveItems">
+                <property name="items_location" value="Toolbelt" />
+                <property name="remove_item_tag" value="amnesiaCurrency" />
+            </action>
+        </action_sequence>
+        <action_sequence name="amnesia_request_change">
+            <action class="AddBuff">
+                <property name="buff_name" value="buffAmnesiaRequestChangeCallback" />
+                <property name="check_already_exists" value="false" />
+            </action>
+        </action_sequence>
+        <!-- TODO: remove, so long as everything else continues to work -->
+        <action_sequence name="amnesia_request_change_cvar">
+            <action class="SetCVar">
+                <property name="cvar" value="amnesiaRequestChangeCallback" />
+                <property name="value" value="1" />
+            </action>
+        </action_sequence>
+    </append>
+</config>

--- a/Config/items.xml
+++ b/Config/items.xml
@@ -1,4 +1,6 @@
 ﻿<config>
+    <append xpath="/items/item[@name='casinoCoin']/property[@name='Tags']/@value">,amnesiaCurrency</append>
+
     <append xpath="/items">
         <item name="drugAmnesiaMemoryBoosters">
             <property name="Tags" value="medical" />

--- a/src/Amnesia.csproj
+++ b/src/Amnesia.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Handlers\SavePlayerData.cs" />
     <Compile Include="Patches\EntityBuffs.cs" />
     <Compile Include="Patches\NetPackagePlayerInventory.cs" />
+    <Compile Include="Patches\NetPackagePlayerStats.cs" />
     <Compile Include="Patches\Progression.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utilities\DialogShop.cs" />

--- a/src/Amnesia.csproj
+++ b/src/Amnesia.csproj
@@ -71,7 +71,11 @@
     <Compile Include="Handlers\GameMessage.cs" />
     <Compile Include="Handlers\PlayerSpawnedInWorld.cs" />
     <Compile Include="Handlers\SavePlayerData.cs" />
+    <Compile Include="Patches\EntityBuffs.cs" />
+    <Compile Include="Patches\NetPackagePlayerInventory.cs" />
+    <Compile Include="Patches\Progression.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Utilities\DialogShop.cs" />
     <Compile Include="Utilities\MessagingSystem.cs" />
     <Compile Include="Utilities\ModLog.cs" />
     <Compile Include="Utilities\PlayerHelper.cs" />

--- a/src/Handlers/PlayerSpawnedInWorld.cs
+++ b/src/Handlers/PlayerSpawnedInWorld.cs
@@ -26,18 +26,20 @@ namespace Amnesia.Handlers
                 }
                 switch (respawnType)
                 {
-                    //case RespawnType.NewGame: // TODO: update to support local players
-                    //case RespawnType.LoadedGame: // TODO: update to support local players
+                    // TODO: case RespawnType.NewGame: // local player creating a new game
                     case RespawnType.EnterMultiplayer: // first-time login for new player
                         _ = PlayerHelper.AddPositiveOutlookTime(player, Config.PositiveOutlookTimeOnFirstJoin);
                         HandleStandardRespawnSteps(player);
-                        DialogShop.UpdateMoney(player.entityId, player.inventory.GetSlots(), player.bag.GetSlots());
+                        DialogShop.UpdatePrices(player);
+                        DialogShop.UpdateMoneyTracker(player.entityId, player.inventory.GetSlots(), player.bag.GetSlots());
                         break;
+                    // TODO: case RespawnType.LoadedGame: // local player loading existing game
                     case RespawnType.JoinMultiplayer: // existing player rejoining
                         // grace period should continue only so long as you don't disconnect
                         player.Buffs.RemoveBuff(Values.BuffPostBloodmoonLifeProtection);
                         HandleStandardRespawnSteps(player);
-                        DialogShop.UpdateMoney(player.entityId, player.inventory.GetSlots(), player.bag.GetSlots());
+                        DialogShop.UpdatePrices(player);
+                        DialogShop.UpdateMoneyTracker(player.entityId, player.inventory.GetSlots(), player.bag.GetSlots());
                         break;
                     case RespawnType.Died: // existing player returned from death
                         _ = PlayerHelper.AddPositiveOutlookTime(player, Config.PositiveOutlookTimeOnMemoryLoss);

--- a/src/Handlers/PlayerSpawnedInWorld.cs
+++ b/src/Handlers/PlayerSpawnedInWorld.cs
@@ -26,20 +26,24 @@ namespace Amnesia.Handlers
                 }
                 switch (respawnType)
                 {
+                    //case RespawnType.NewGame: // TODO: update to support local players
+                    //case RespawnType.LoadedGame: // TODO: update to support local players
                     case RespawnType.EnterMultiplayer: // first-time login for new player
                         _ = PlayerHelper.AddPositiveOutlookTime(player, Config.PositiveOutlookTimeOnFirstJoin);
-                        RefundHardenedMemory(clientInfo, player);
                         HandleStandardRespawnSteps(player);
+                        DialogShop.UpdateMoney(player.entityId, player.inventory.GetSlots(), player.bag.GetSlots());
                         break;
                     case RespawnType.JoinMultiplayer: // existing player rejoining
                         // grace period should continue only so long as you don't disconnect
                         player.Buffs.RemoveBuff(Values.BuffPostBloodmoonLifeProtection);
-                        RefundHardenedMemory(clientInfo, player);
                         HandleStandardRespawnSteps(player);
+                        DialogShop.UpdateMoney(player.entityId, player.inventory.GetSlots(), player.bag.GetSlots());
                         break;
                     case RespawnType.Died: // existing player returned from death
                         _ = PlayerHelper.AddPositiveOutlookTime(player, Config.PositiveOutlookTimeOnMemoryLoss);
                         HandleStandardRespawnSteps(player);
+                        // TODO: test without first; it should automatically update upon bag drop or whatnot
+                        //DialogShop.UpdateMoney(player.entityId, player.inventory.GetSlots(), player.bag.GetSlots());
                         break;
                 }
             }
@@ -87,19 +91,6 @@ namespace Amnesia.Handlers
                 // remove/clean up since protection is inactive
                 player.Buffs.RemoveBuff(Values.BuffBloodmoonLifeProtection);
                 player.Buffs.RemoveBuff(Values.BuffPostBloodmoonLifeProtection);
-            }
-        }
-
-        /// <summary>
-        /// Temporary method to automatically refund any players with the Hardened Memory buff from version 1.0.0.
-        /// </summary>
-        /// <param name="player">EntityPlayer to check buffs for and refund if hardened.</param>
-        private static void RefundHardenedMemory(ClientInfo clientInfo, EntityPlayer player)
-        {
-            if (player.Buffs.HasBuff(Values.BuffHardenedMemory))
-            {
-                PlayerHelper.GiveItem(clientInfo, player, Values.NameMemoryBoosters);
-                player.Buffs.RemoveBuff(Values.BuffHardenedMemory);
             }
         }
     }

--- a/src/ModApi.cs
+++ b/src/ModApi.cs
@@ -8,7 +8,7 @@ namespace Amnesia
 {
     internal class ModApi : IModApi
     {
-        public static bool DebugMode { get; set; } = false;
+        public static bool DebugMode { get; set; } = true; // TODO: set to false before release
         public static Dictionary<int, bool> Obituary { get; private set; } = new Dictionary<int, bool>();
 
         public void InitMod(Mod _modInstance)

--- a/src/Patches/EntityBuffs.cs
+++ b/src/Patches/EntityBuffs.cs
@@ -1,0 +1,155 @@
+﻿using Amnesia.Utilities;
+using HarmonyLib;
+using System;
+
+namespace Amnesia.Patches
+{
+    /// <summary>
+    /// Monitor added buffs.
+    /// </summary>
+    /// <remarks>Supports: local and remote</remarks>
+    [HarmonyPatch(typeof(EntityBuffs), "AddBuff")]
+    internal class EntityBuffs_AddBuff_Patches
+    {
+        private const string BUFF_TRY_BUY_TREATMENT_NAME = "buffAmnesiaTryBuyTreatment";
+        private const string BUFF_REQUEST_CHANGE_CALLBACK_NAME = "buffAmnesiaRequestChangeCallback";
+        private const string BUFF_FRAGILE_MEMORY_NAME = "buffAmnesiaFragileMemory";
+
+        private static readonly ModLog<EntityBuffs_AddBuff_Patches> _log = new ModLog<EntityBuffs_AddBuff_Patches>();
+
+        public static void Postfix(EntityBuffs __instance, string _name)
+        {
+            try
+            {
+                switch (_name)
+                {
+                    case BUFF_TRY_BUY_TREATMENT_NAME:
+                        TryBuy(__instance.parent);
+                        return;
+                    case BUFF_REQUEST_CHANGE_CALLBACK_NAME:
+                        TryGiveChange(__instance.parent);
+                        return;
+                }
+            }
+            catch (Exception e)
+            {
+                _log.Error("Postfix", e);
+            }
+        }
+
+        private static void TryBuy(EntityAlive entity)
+        {
+            if (!entity.isEntityRemote)
+            {
+                var entityPlayerLocal = entity.world.GetPrimaryPlayer();
+                entityPlayerLocal.Buffs.RemoveBuff(BUFF_TRY_BUY_TREATMENT_NAME);
+                if (!entityPlayerLocal.Buffs.HasBuff(BUFF_FRAGILE_MEMORY_NAME))
+                {
+                    _log.Trace($"player {entityPlayerLocal.GetDebugName()} doesn't have {BUFF_FRAGILE_MEMORY_NAME}");
+                    _log.Debug("TODO: {tipTreatmentNotNecessary}: You have no need of Treatment since [00ff80]your memory is already healthy[-]. Please visit again if you acquire a [ff8000]Fragile Memory[-].");
+                    // TODO: play sad/cancel sound
+                }
+                else if (DialogShop.TryPurchase(entityPlayerLocal, DialogShop.GetCost(entityPlayerLocal.Progression.Level, Product.Treatment)))
+                {
+                    _log.Trace("success");
+                    entityPlayerLocal.Buffs.RemoveBuff(BUFF_FRAGILE_MEMORY_NAME);
+                    _log.Debug("TODO: {tipTreatmentComplete}: [00ff80]Your treatment is now complete[-] and your memory has returned to a health state. Please come again!");
+                    // TODO: play trader sound ui_trader_purchase in head?
+                }
+                else
+                {
+                    _log.Trace("failure");
+                    _log.Debug("TODO: {tipCannotAfford}: [ff8000]You do not have the necessary funds[-] for this procedure. Please return when you do.");
+                    // TODO: play sad/cancel sound
+                }
+                return;
+            }
+
+            if (PlayerHelper.TryGetClientInfoAndEntityPlayer(entity.world, entity.entityId, out var clientInfo, out var player))
+            {
+                player.Buffs.RemoveBuff(BUFF_TRY_BUY_TREATMENT_NAME);
+                if (!player.Buffs.HasBuff(BUFF_FRAGILE_MEMORY_NAME))
+                {
+                    _log.Trace($"player {player.GetDebugName()} doesn't have {BUFF_FRAGILE_MEMORY_NAME}");
+                    _log.Debug("TODO: {tipTreatmentNotNecessary}: You have no need of Treatment since [00ff80]your memory is already healthy[-]. Please visit again if you acquire a [ff8000]Fragile Memory[-].");
+                    // TODO: play sad/cancel sound
+                }
+                else if (DialogShop.TryPurchase(clientInfo, player, DialogShop.GetCost(player.Progression.Level, Product.Treatment)))
+                {
+                    _log.Trace("success");
+                    player.Buffs.RemoveBuff(BUFF_FRAGILE_MEMORY_NAME);
+                    _log.Debug("TODO: {tipTreatmentComplete}: [00ff80]Your treatment is now complete[-] and your memory has returned to a health state. Please come again!");
+                    // TODO: play trader sound ui_trader_purchase in head?
+                }
+                else
+                {
+                    _log.Trace("failure");
+                    _log.Debug("TODO: {tipCannotAfford}: [ff8000]You do not have the necessary funds[-] for this procedure. Please return when you do.");
+                    // TODO: play sad/cancel sound
+                }
+            }
+        }
+
+        private static void TryGiveChange(EntityAlive entity)
+        {
+            if (!entity.isEntityRemote)
+            {
+                var entityPlayerLocal = entity.world.GetPrimaryPlayer();
+                entityPlayerLocal.Buffs.RemoveBuff(BUFF_REQUEST_CHANGE_CALLBACK_NAME);
+                DialogShop.GiveChange(entityPlayerLocal);
+                return;
+            }
+
+            if (PlayerHelper.TryGetClientInfoAndEntityPlayer(entity.world, entity.entityId, out var clientInfo, out var player))
+            {
+                player.Buffs.RemoveBuff(BUFF_REQUEST_CHANGE_CALLBACK_NAME);
+                DialogShop.GiveChange(clientInfo, player);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Monitor setting of cvars.
+    /// </summary>
+    /// <remarks>Supports: local and remote</remarks>
+    //[HarmonyPatch(typeof(EntityBuffs), "SetCustomVar")]
+    // TODO: remove, so long as everything else continues to work
+    internal class EntityBuffs_SetCustomVar_Patches
+    {
+        private static readonly ModLog<EntityBuffs_SetCustomVar_Patches> _log = new ModLog<EntityBuffs_SetCustomVar_Patches>();
+
+        public static void Postfix(EntityBuffs __instance, string _name, float _value)
+        {
+            try
+            {
+                if (!DialogShop.GAME_EVENT_REQUEST_CHANGE.EqualsCaseInsensitive(_name)
+                    || _value != 1
+                    || !__instance.parent.world.Players.dict.TryGetValue(__instance.parent.entityId, out var player))
+                {
+                    return;
+                }
+
+                if (!__instance.parent.isEntityRemote)
+                {
+                    player.SetCVar(_name, 0); // unset value
+                    DialogShop.GiveChange(player.world.GetPrimaryPlayer());
+                    return;
+                }
+
+                var clientInfo = ConnectionManager.Instance.Clients.ForEntityId(__instance.parent.entityId);
+                if (clientInfo == null)
+                {
+                    _log.Error($"Remote player {__instance.parent.GetDebugName()} ({__instance.parent.entityId}) did not seem to have an active connection; failing to return change.");
+                    return;
+                }
+
+                player.SetCVar(_name, 0); // unset value
+                DialogShop.GiveChange(clientInfo, player);
+            }
+            catch (Exception e)
+            {
+                _log.Error("Postfix", e);
+            }
+        }
+    }
+}

--- a/src/Patches/NetPackagePlayerInventory.cs
+++ b/src/Patches/NetPackagePlayerInventory.cs
@@ -15,7 +15,7 @@ namespace Amnesia.Patches
             {
                 if (___toolbelt == null && ___bag == null) { return; }
                 var entityId = __instance.Sender.entityId; // TODO: refactor to support local player
-                DialogShop.UpdateMoney(entityId, ___toolbelt, ___bag);
+                DialogShop.UpdateMoneyTracker(entityId, ___toolbelt, ___bag);
             }
             catch (Exception e)
             {

--- a/src/Patches/NetPackagePlayerInventory.cs
+++ b/src/Patches/NetPackagePlayerInventory.cs
@@ -1,0 +1,26 @@
+﻿using Amnesia.Utilities;
+using HarmonyLib;
+using System;
+
+namespace Amnesia.Patches
+{
+    [HarmonyPatch(typeof(NetPackagePlayerInventory), "ProcessPackage")]
+    internal class NetPackagePlayerInventory_ProcessPackage_Patch
+    {
+        private static readonly ModLog<NetPackagePlayerInventory_ProcessPackage_Patch> _log = new ModLog<NetPackagePlayerInventory_ProcessPackage_Patch>();
+
+        public static void Postfix(NetPackagePlayerInventory __instance, World _world, ItemStack[] ___toolbelt, ItemStack[] ___bag)
+        {
+            try
+            {
+                if (___toolbelt == null && ___bag == null) { return; }
+                var entityId = __instance.Sender.entityId; // TODO: refactor to support local player
+                DialogShop.UpdateMoney(entityId, ___toolbelt, ___bag);
+            }
+            catch (Exception e)
+            {
+                _log.Error("Postfix", e);
+            }
+        }
+    }
+}

--- a/src/Patches/NetPackagePlayerStats.cs
+++ b/src/Patches/NetPackagePlayerStats.cs
@@ -1,0 +1,58 @@
+﻿using Amnesia.Utilities;
+using HarmonyLib;
+using System;
+
+namespace Amnesia.Patches
+{
+    /// <summary>
+    /// Detect level and other stat changes.
+    /// </summary>
+    /// <remarks>Supports: remote </remarks>
+    [HarmonyPatch(typeof(NetPackagePlayerStats), "ProcessPackage")]
+    internal class NetPackagePlayerStats_ProcessPackage_Patches
+    {
+        private static readonly ModLog<NetPackagePlayerStats_ProcessPackage_Patches> _log = new ModLog<NetPackagePlayerStats_ProcessPackage_Patches>();
+
+        public static void Prefix(World _world, int ___entityId, int ___level, out bool __state)
+        {
+            __state = false; // default to ignore
+            try
+            {
+                if (!ConnectionManager.Instance.IsServer
+                    || !_world.Players.dict.TryGetValue(___entityId, out var player))
+                {
+                    return;
+                }
+
+                if (player.Progression.Level != ___level)
+                {
+                    _log.Trace($"refreshing price for player {player.GetDebugName()} due to change in level: {player.Progression.Level} -> {___level}");
+                    __state = true;
+                }
+            }
+            catch (Exception e)
+            {
+                _log.Error("Prefix", e);
+            }
+        }
+
+        public static void Postfix(World _world, int ___entityId, bool __state)
+        {
+            try
+            {
+                if (!ConnectionManager.Instance.IsServer
+                    || !__state
+                    || !_world.Players.dict.TryGetValue(___entityId, out var player))
+                {
+                    return;
+                }
+
+                DialogShop.UpdatePrices(player);
+            }
+            catch (Exception e)
+            {
+                _log.Error("Postfix", e);
+            }
+        }
+    }
+}

--- a/src/Patches/Progression.cs
+++ b/src/Patches/Progression.cs
@@ -5,9 +5,9 @@ using System;
 namespace Amnesia.Patches
 {
     /// <summary>
-    /// Detect level change and update weight/gear values.
+    /// Detect level change.
     /// </summary>
-    /// <remarks>local players</remarks>
+    /// <remarks>Supports: local </remarks>
     [HarmonyPatch(typeof(Progression), "AddLevelExp")]
     internal class Progression_AddLevelExp_Patches
     {
@@ -18,7 +18,8 @@ namespace Amnesia.Patches
             __state = -1; // default to ignore
             try
             {
-                if (!ConnectionManager.Instance.IsServer // TODO: do these checks in many more parts of the code to support remote having local mod (disable remote clients)
+                // TODO: do these checks in many more parts of the code to support remote having local mod (disable remote clients)
+                if (!ConnectionManager.Instance.IsServer
                     || __instance.parent.isEntityRemote // only track local entity
                     || !(__instance.parent is EntityPlayerLocal)) // only track EntityPlayerLocal
                 {
@@ -26,7 +27,6 @@ namespace Amnesia.Patches
                 }
 
                 __state = ___Level;
-                // TODO: ?
             }
             catch (Exception e)
             {
@@ -47,10 +47,12 @@ namespace Amnesia.Patches
                 }
 
                 _log.Trace($"change in player level detected: {__state} -> {___Level}");
-                //WeightManager.UpdatePlayerWeight(player, player.inventory.GetSlots(), player.bag.GetSlots(), player.equipment);
-                // TODO: add behavior
 
                 // TOOD: calculate and push amnesia treatment and therapy costs as levels change...? Or perhaps as skill points change?
+                DialogShop.UpdatePrices(player);
+
+                //WeightManager.UpdatePlayerWeight(player, player.inventory.GetSlots(), player.bag.GetSlots(), player.equipment);
+                // TODO: add behavior
 
                 // TODO: (in another hook) as each skill point is applied, record that added skill point in permanent memory and write to drive
             }

--- a/src/Patches/Progression.cs
+++ b/src/Patches/Progression.cs
@@ -1,0 +1,63 @@
+﻿using Amnesia.Utilities;
+using HarmonyLib;
+using System;
+
+namespace Amnesia.Patches
+{
+    /// <summary>
+    /// Detect level change and update weight/gear values.
+    /// </summary>
+    /// <remarks>local players</remarks>
+    [HarmonyPatch(typeof(Progression), "AddLevelExp")]
+    internal class Progression_AddLevelExp_Patches
+    {
+        private static readonly ModLog<Progression_AddLevelExp_Patches> _log = new ModLog<Progression_AddLevelExp_Patches>();
+
+        public static void Prefix(Progression __instance, int ___Level, out int __state)
+        {
+            __state = -1; // default to ignore
+            try
+            {
+                if (!ConnectionManager.Instance.IsServer // TODO: do these checks in many more parts of the code to support remote having local mod (disable remote clients)
+                    || __instance.parent.isEntityRemote // only track local entity
+                    || !(__instance.parent is EntityPlayerLocal)) // only track EntityPlayerLocal
+                {
+                    return;
+                }
+
+                __state = ___Level;
+                // TODO: ?
+            }
+            catch (Exception e)
+            {
+                _log.Error("Prefix", e);
+            }
+        }
+
+        public static void Postfix(Progression __instance, int ___Level, int __state)
+        {
+            try
+            {
+                if (!ConnectionManager.Instance.IsServer
+                    || __state == -1
+                    || __state == ___Level
+                    || !(__instance.parent is EntityPlayerLocal player))
+                {
+                    return;
+                }
+
+                _log.Trace($"change in player level detected: {__state} -> {___Level}");
+                //WeightManager.UpdatePlayerWeight(player, player.inventory.GetSlots(), player.bag.GetSlots(), player.equipment);
+                // TODO: add behavior
+
+                // TOOD: calculate and push amnesia treatment and therapy costs as levels change...? Or perhaps as skill points change?
+
+                // TODO: (in another hook) as each skill point is applied, record that added skill point in permanent memory and write to drive
+            }
+            catch (Exception e)
+            {
+                _log.Error("Postfix", e);
+            }
+        }
+    }
+}

--- a/src/Utilities/DialogShop.cs
+++ b/src/Utilities/DialogShop.cs
@@ -1,0 +1,186 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Amnesia.Utilities
+{
+    internal enum Product
+    {
+        Treatment, Therapy
+    }
+
+    internal class DialogShop
+    {
+        private const string GAME_EVENT_PAY_FROM_BAG = "amnesia_pay_from_bag";
+        private const string GAME_EVENT_PAY_FROM_BLT = "amnesia_pay_from_blt";
+        public const string GAME_EVENT_REQUEST_CHANGE = "amnesia_request_change";
+
+        private static readonly ModLog<DialogShop> _log = new ModLog<DialogShop>();
+        private static readonly ItemValue CASINO_COIN_ITEM_VALUE = ItemClass.GetItem("casinoCoin", false);
+        private static readonly FastTags moneyTag = FastTags.Parse("amnesiaCurrency");
+
+        public static Dictionary<int, int> BagMoney { get; private set; } = new Dictionary<int, int>();
+        public static Dictionary<int, int> BltMoney { get; private set; } = new Dictionary<int, int>();
+        public static Dictionary<int, int> Change { get; private set; } = new Dictionary<int, int>();
+
+        public static void UpdateMoney(int entityId, ItemStack[] ___toolbelt = null, ItemStack[] ___bag = null)
+        {
+            if (___toolbelt != null) { BltMoney[entityId] = CountCoins(___toolbelt); }
+            if (___bag != null) { BagMoney[entityId] = CountCoins(___bag); }
+
+            _ = BltMoney.TryGetValue(entityId, out var blt);
+            _ = BagMoney.TryGetValue(entityId, out var bag);
+            _log.Debug($"blt: {blt}, bag: {bag}, total: {blt + bag}");
+        }
+
+        public static void GiveChange(ClientInfo clientInfo, EntityPlayer player)
+        {
+            if (!Change.TryGetValue(clientInfo.entityId, out var value))
+            {
+                _log.Error($"Client requested change for {clientInfo.entityId}, but there is no change cached to return; this is unexpected");
+                return;
+            }
+            AddCoins(clientInfo, player.position, value);
+            _log.Trace($"change returned to {player.GetDebugName()} ({player.entityId}) in the amount of {value}");
+        }
+
+        public static void GiveChange(EntityPlayerLocal player)
+        {
+            if (!Change.TryGetValue(player.entityId, out var value))
+            {
+                _log.Error($"Client requested change for {player.entityId}, but there is no change cached to return; this is unexpected");
+                return;
+            }
+            AddCoins(player, value);
+        }
+
+        public static int GetCost(int level, Product product)
+        {
+            switch (product)
+            {
+                case Product.Treatment:
+                    return 1200 * level;
+                case Product.Therapy:
+                    return 600 * level;
+            }
+            return -1;
+        }
+
+        public static bool TryPurchase(ClientInfo clientInfo, EntityPlayer player, int cost)
+        {
+            if (CanAfford(player.entityId, cost))
+            {
+                _log.Trace($"player {player.GetDebugName()} could afford {cost}");
+                Pay(clientInfo, player, cost);
+                return true;
+            }
+            _log.Trace($"player {player.GetDebugName()} could NOT afford {cost}");
+            return false;
+        }
+
+        internal static bool TryPurchase(EntityPlayerLocal player, int cost)
+        {
+            throw new NotImplementedException(); // TODO: complete for local player support
+        }
+
+        private static bool CanAfford(int entityId, int amount)
+        {
+            _ = BagMoney.TryGetValue(entityId, out var bag);
+            _ = BltMoney.TryGetValue(entityId, out var blt);
+            return bag + blt - amount >= 0;
+        }
+
+        public static void Pay(ClientInfo clientInfo, EntityPlayer player, int cost)
+        {
+            _log.Trace($"player {player.GetDebugName()} charge attempt for {cost}");
+            if (BagMoney.TryGetValue(clientInfo.entityId, out var bag))
+            {
+                TriggerGameEvent(clientInfo, player, GAME_EVENT_PAY_FROM_BAG);
+                if (bag >= cost)
+                {
+                    if (bag > cost)
+                    {
+                        //AddCoins(clientInfo, player.position, bag - cost);
+                        //BagMoney[player.entityId] = bag - cost;
+                        Change.Add(player.entityId, bag - cost);
+                        TriggerGameEvent(clientInfo, player, GAME_EVENT_REQUEST_CHANGE);
+                    }
+                    else
+                    {
+                        //BagMoney[player.entityId] = 0;
+                    }
+                    return;
+                }
+                cost -= bag;
+            }
+            if (BltMoney.TryGetValue(clientInfo.entityId, out var blt))
+            {
+                TriggerGameEvent(clientInfo, player, GAME_EVENT_PAY_FROM_BLT);
+                if (blt > cost)
+                {
+                    //AddCoins(clientInfo, player.position, blt - cost);
+                    //BltMoney[player.entityId] = blt - cost;
+                    Change.Add(player.entityId, blt - cost);
+                    TriggerGameEvent(clientInfo, player, GAME_EVENT_REQUEST_CHANGE);
+                }
+                else
+                {
+                    //BltMoney[player.entityId] = 0;
+                }
+            }
+        }
+
+        private static void TriggerGameEvent(ClientInfo clientInfo, EntityPlayer player, string eventName)
+        {
+            // TODO: handle return value? (false may mean failure)
+            _ = GameEventManager.Current.HandleAction(eventName, null, player, false);
+            clientInfo.SendPackage(NetPackageManager.GetPackage<NetPackageGameEventResponse>().Setup(eventName, clientInfo.playerName, "", "", NetPackageGameEventResponse.ResponseTypes.Approved));
+        }
+
+        private static void AddCoins(ClientInfo clientInfo, Vector3 pos, int amount)
+        {
+            var itemStack = new ItemStack(CASINO_COIN_ITEM_VALUE, amount);
+            var entityId = EntityFactory.nextEntityID++;
+            GameManager.Instance.World.SpawnEntityInWorld((EntityItem)EntityFactory.CreateEntity(new EntityCreationData
+            {
+                entityClass = EntityClass.FromString("item"),
+                id = entityId,
+                itemStack = itemStack,
+                pos = pos,
+                rot = new Vector3(20f, 0f, 20f),
+                lifetime = 60f,
+                belongsPlayerId = clientInfo.entityId
+            }));
+            clientInfo.SendPackage(NetPackageManager.GetPackage<NetPackageEntityCollect>().Setup(entityId, clientInfo.entityId));
+            _ = GameManager.Instance.World.RemoveEntity(entityId, EnumRemoveEntityReason.Despawned);
+        }
+
+        private static void AddCoins(EntityPlayerLocal player, int amount)
+        {
+            player.AddUIHarvestingItem(new ItemStack(CASINO_COIN_ITEM_VALUE, amount));
+        }
+
+        private static int CountCoins(ItemStack[] stack)
+        {
+            var _count = 0;
+            for (var i = 0; i < stack.Length; i++)
+            {
+                if (stack[i].IsEmpty())
+                {
+                    continue;
+                }
+                var itemValue = stack[i].itemValue;
+                if (itemValue == null) { continue; } // TODO: this sanity check is probably not necessary
+                _log.Trace($"{itemValue.GetItemId()}");
+                var itemClass = itemValue.ItemClass;
+                if (itemClass == null) { continue; } // TODO: this sanity check is probably not necessary
+                _log.Trace($"name: {itemClass.Name}");
+                if (itemClass.HasAnyTags(moneyTag))
+                {
+                    _count += stack[i].count;
+                }
+            }
+            return _count;
+        }
+    }
+}

--- a/src/Utilities/DialogShop.cs
+++ b/src/Utilities/DialogShop.cs
@@ -15,6 +15,9 @@ namespace Amnesia.Utilities
         private const string GAME_EVENT_PAY_FROM_BLT = "amnesia_pay_from_blt";
         public const string GAME_EVENT_REQUEST_CHANGE = "amnesia_request_change";
 
+        private const string CVAR_TREATMENT_PRICE_NAME = "amnesiaTreatmentPrice";
+        private const string CVAR_THERAPY_PRICE_NAME = "amnesiaTherapyPrice";
+
         private static readonly ModLog<DialogShop> _log = new ModLog<DialogShop>();
         private static readonly ItemValue CASINO_COIN_ITEM_VALUE = ItemClass.GetItem("casinoCoin", false);
         private static readonly FastTags moneyTag = FastTags.Parse("amnesiaCurrency");
@@ -23,7 +26,7 @@ namespace Amnesia.Utilities
         public static Dictionary<int, int> BltMoney { get; private set; } = new Dictionary<int, int>();
         public static Dictionary<int, int> Change { get; private set; } = new Dictionary<int, int>();
 
-        public static void UpdateMoney(int entityId, ItemStack[] ___toolbelt = null, ItemStack[] ___bag = null)
+        public static void UpdateMoneyTracker(int entityId, ItemStack[] ___toolbelt = null, ItemStack[] ___bag = null)
         {
             if (___toolbelt != null) { BltMoney[entityId] = CountCoins(___toolbelt); }
             if (___bag != null) { BagMoney[entityId] = CountCoins(___bag); }
@@ -31,6 +34,11 @@ namespace Amnesia.Utilities
             _ = BltMoney.TryGetValue(entityId, out var blt);
             _ = BagMoney.TryGetValue(entityId, out var bag);
             _log.Debug($"blt: {blt}, bag: {bag}, total: {blt + bag}");
+        }
+
+        public static void UpdatePrices(EntityPlayer player)
+        {
+            player.SetCVar(CVAR_TREATMENT_PRICE_NAME, GetCost(player.Progression.Level, Product.Treatment));
         }
 
         public static void GiveChange(ClientInfo clientInfo, EntityPlayer player)

--- a/src/Utilities/PlayerHelper.cs
+++ b/src/Utilities/PlayerHelper.cs
@@ -6,7 +6,35 @@ namespace Amnesia.Utilities
 {
     internal class PlayerHelper
     {
-        private static readonly ModLog<PlayerHelper> log = new ModLog<PlayerHelper>();
+        private static readonly ModLog<PlayerHelper> _log = new ModLog<PlayerHelper>();
+
+        public static bool TryGetClientInfo(int entityId, out ClientInfo clientInfo)
+        {
+            clientInfo = ConnectionManager.Instance.Clients.ForEntityId(entityId);
+            if (clientInfo == null)
+            {
+                _log.Error($"Could not retrieve remote player connection for {entityId}");
+                return false;
+            }
+            return true;
+        }
+
+        public static bool TryGetClientInfoAndEntityPlayer(World world, int entityId, out ClientInfo clientInfo, out EntityPlayer player)
+        {
+            clientInfo = ConnectionManager.Instance.Clients.ForEntityId(entityId);
+            if (clientInfo == null)
+            {
+                _log.Error($"Could not retrieve remote player connection for {entityId}");
+                player = null;
+                return false;
+            }
+            if (!world.Players.dict.TryGetValue(entityId, out player))
+            {
+                _log.Error($"Could not retrieve player for {entityId}");
+                return false;
+            }
+            return true;
+        }
 
         /// <remarks>Most of the following core logic was lifted from ActionResetPlayerData.PerformTargetAction</remarks>
         public static void ResetPlayer(EntityPlayer player)
@@ -63,7 +91,7 @@ namespace Amnesia.Utilities
                     }
                     catch (Exception e)
                     {
-                        log.Error("Failed to scan for completed skillpoints.", e);
+                        _log.Error("Failed to scan for completed skillpoints.", e);
                     }
                 }
 
@@ -92,7 +120,7 @@ namespace Amnesia.Utilities
             _ = player.Buffs.AddBuff(Values.BuffMemoryLoss);
             if (Config.PositiveOutlookTimeOnMemoryLoss > 0)
             {
-                log.Trace($"{player.GetDebugName()} will receive the Positive Outlook buff.");
+                _log.Trace($"{player.GetDebugName()} will receive the Positive Outlook buff.");
                 player.SetCVar(Values.CVarPositiveOutlookRemTime, Config.PositiveOutlookTimeOnMemoryLoss);
                 _ = player.Buffs.AddBuff(Values.BuffPositiveOutlook);
             }


### PR DESCRIPTION
- add admin command to give/heal fragile memory
- fix bug allowing bypass of pvp protection
- fix/update admin command players

command | details
--- | ---
`amn players` | show players and their amnesia-related info (updated to include fragile memory)
`amn fragile <user id / player name / entity id> <true/false>` | convenience method: give or remove fragile memory debuff